### PR TITLE
Wrap JSON parse in try..catch block

### DIFF
--- a/lib/gerrit-event-emitter.js
+++ b/lib/gerrit-event-emitter.js
@@ -64,9 +64,13 @@ GerritEventEmitter.prototype.onStreamWrite = function(output) {
   output.toString('utf-8').split("\n").forEach(function(jsonString) {
     if (typeof jsonString !== 'string' || jsonString.length === 0) { return; }
 
-    var eventData = JSON.parse(jsonString);
-    var camelizedEventName = _this.toCamelizedEventName(eventData.type);
-    _this.emit(camelizedEventName, eventData);
+    try {
+      var eventData = JSON.parse(jsonString);
+      var camelizedEventName = _this.toCamelizedEventName(eventData.type);
+      _this.emit(camelizedEventName, eventData);
+    } catch (e) {
+      console.error('Unable to parse JSON string:', e);
+    }
   });
 };
 


### PR DESCRIPTION
Sometimes the jsonstring is malformed and kills the app
silently.